### PR TITLE
Fix Prisma client usage in API routes

### DIFF
--- a/app/api/consultation/route.ts
+++ b/app/api/consultation/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/db";
 
-const prisma = new PrismaClient();
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN!;
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID!;

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/db";
 
-const prisma = new PrismaClient();
 
 const TELEGRAM_TOKEN = "7220685191:AAGuyb08-itj1OkltImBBBC6yL-TCyhqs50";
 const TELEGRAM_CHAT_ID = "7808843941"; // ← Twój prawdziwy ID z @userinfobot

--- a/app/api/subscribers/route.ts
+++ b/app/api/subscribers/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
 
 export async function POST(request: Request) {
   try {


### PR DESCRIPTION
## Summary
- reuse shared Prisma client in API routes to avoid connection bloat

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bce9d51c8332a8e90db3446eae64