### PR TITLE
Add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# 📦 Baza danych
+DATABASE_URL="postgresql://user:password@localhost:5432/vehixdb"
+
+# 🤖 Telegram Bot
+TELEGRAM_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_chat_id

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .next
 .DS_Store
 public/images/**/.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Strona internetowa dla firmy Vehix zajmującej się importem samochodów z USA.
 npm install
 ```
 
-3. Skopiuj plik `.env.example` do `.env` i uzupełnij dane dostępowe do bazy danych:
+3. Skopiuj plik `.env.example` do `.env` i uzupełnij zmienne środowiskowe:
 
 ```bash
 cp .env.example .env
@@ -65,12 +65,20 @@ npm run dev
 - `public/` - Statyczne pliki (obrazy, fonty, itp.)
 - `lib/` - Funkcje pomocnicze i konfiguracja
 
+## Zmienne środowiskowe
+
+W projekcie wymagane są następujące zmienne:
+
+- `DATABASE_URL` – adres URL bazy danych PostgreSQL
+- `TELEGRAM_TOKEN` – token bota Telegram
+- `TELEGRAM_CHAT_ID` – ID czatu do wysyłania powiadomień
+
 ## Wdrożenie
 
 Aplikacja jest gotowa do wdrożenia na platformach takich jak Vercel, Netlify czy AWS.
 
 1. Skonfiguruj bazę danych PostgreSQL
-2. Ustaw zmienne środowiskowe (DATABASE_URL)
+2. Ustaw zmienne środowiskowe (DATABASE_URL, TELEGRAM_TOKEN, TELEGRAM_CHAT_ID)
 3. Wdróż aplikację za pomocą preferowanej platformy
 
 ## Licencja

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -3,8 +3,8 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-const TELEGRAM_TOKEN = "7220685191:AAGuyb08-itj1OkltImBBBC6yL-TCyhqs50";
-const TELEGRAM_CHAT_ID = "7808843941"; // ← Twój prawdziwy ID z @userinfobot
+const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN!;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID!;
 
 export async function POST(req: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders
- ignore `.env`
- load Telegram config from environment
- document required environment variables in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c6bd07cc83328831a2d50b107d3c